### PR TITLE
fix: Python integer out of bounds for uint8

### DIFF
--- a/qoi-conv/__init__.py
+++ b/qoi-conv/__init__.py
@@ -4,5 +4,5 @@ qoi
 An sample implementation of the QOI Image format in python
 """
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"
 __author__= "Martin Oehzelt"

--- a/qoi-conv/qoi.py
+++ b/qoi-conv/qoi.py
@@ -47,7 +47,12 @@ class Pixel:
         return Pixel(r, g, b, self.a)
 
     def hash(self) -> int:
-        return ((self.r * 3 + self.g * 5 + self.b * 7 + self.a * 11) % 64)
+        r = int(self.r)
+        g = int(self.g)
+        b = int(self.b)
+        a = int(self.a)
+        hash_val = (r * 3 + g * 5 + b * 7 + a * 11) % 64
+        return hash_val
 
 class Qoi:
     QOI_OP_RGB  = 0b11111110 # 254


### PR DESCRIPTION
Fix the OverflowError:
`OverflowError: Python integer 2805 out of bounds for uint8`